### PR TITLE
test: NavigationBar component UI test

### DIFF
--- a/src/__test__/NavigationBar.test.tsx
+++ b/src/__test__/NavigationBar.test.tsx
@@ -1,0 +1,67 @@
+import { render, fireEvent, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { useRouter, usePathname } from 'next/navigation';
+
+import { NavigationBar } from '@/components';
+
+jest.mock('next/navigation', () => ({
+  useRouter: jest.fn(),
+  usePathname: jest.fn(),
+}));
+
+describe('내비게이션 바 스냅샷 테스트', () => {
+  let mockRouter: { replace: jest.Mock };
+  let mockUsePathname: jest.Mock;
+
+  beforeEach(() => {
+    mockRouter = {
+      replace: jest.fn(),
+    };
+    mockUsePathname = usePathname as jest.Mock;
+    (useRouter as jest.Mock).mockReturnValue(mockRouter);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('pathname이 /login 이거나 /my 인 경우에는 내비게이션 바가 렌더링되지 않아야 합니다.', () => {
+    mockUsePathname.mockReturnValue('/login');
+    const { container } = render(<NavigationBar />);
+    expect(container.firstChild).toBeNull();
+
+    mockUsePathname.mockReturnValue('/my');
+    const { container: container2 } = render(<NavigationBar />);
+    expect(container2.firstChild).toBeNull();
+  });
+
+  test('pathname이 /travel인 경우 여행하기 메뉴가 활성화 되어야 합니다.', () => {
+    mockUsePathname.mockReturnValue('/travel');
+    render(<NavigationBar />);
+
+    expect(screen.getByAltText('travel-active-menu')).toBeInTheDocument();
+    expect(screen.getByText('여행하기')).toHaveStyle('color: #605EFF');
+  });
+
+  test('pathname이 /인 경우 홈 메뉴가 활성화 되어야 합니다.', () => {
+    mockUsePathname.mockReturnValue('/');
+    render(<NavigationBar />);
+
+    expect(screen.getByAltText('home-active-menu')).toBeInTheDocument();
+    expect(screen.getByText('홈')).toHaveStyle('color: #605EFF');
+  });
+
+  test('pathname이 /record인 경우 기록하기 메뉴가 활성화 되어야 합니다.', () => {
+    mockUsePathname.mockReturnValue('/record');
+    render(<NavigationBar />);
+
+    expect(screen.getByAltText('record-active-menu')).toBeInTheDocument();
+    expect(screen.getByText('기록하기')).toHaveStyle('color: #605EFF');
+  });
+
+  test('여행하기 메뉴에 클릭 이벤트가 발생한 경우 router가 /travel 로 replace 되어야 합니다.', () => {});
+
+  test('홈 메뉴에 클릭 이벤트가 발생한 경우 router가 / 로 replace 되어야 합니다.', () => {});
+
+  test('기록하기 메뉴에 클릭 이벤트가 발생한 경우 router가 /record 로 replace 되어야 합니다.', () => {});
+});

--- a/src/__test__/NavigationBar.test.tsx
+++ b/src/__test__/NavigationBar.test.tsx
@@ -35,6 +35,15 @@ describe('내비게이션 바 스냅샷 테스트', () => {
     expect(container2.firstChild).toBeNull();
   });
 
+  test('pathname이 /login 이나 /my가 아닌 경우 내비게이션 바가 렌더링 되어야 합니다.', () => {
+    mockUsePathname.mockReturnValue('/test');
+
+    const { getByText } = render(<NavigationBar />);
+    expect(getByText('여행하기')).toBeInTheDocument();
+    expect(getByText('홈')).toBeInTheDocument();
+    expect(getByText('기록하기')).toBeInTheDocument();
+  });
+
   test('pathname이 /travel인 경우 여행하기 메뉴가 활성화 되어야 합니다.', () => {
     mockUsePathname.mockReturnValue('/travel');
     render(<NavigationBar />);
@@ -59,9 +68,30 @@ describe('내비게이션 바 스냅샷 테스트', () => {
     expect(screen.getByText('기록하기')).toHaveStyle('color: #605EFF');
   });
 
-  test('여행하기 메뉴에 클릭 이벤트가 발생한 경우 router가 /travel 로 replace 되어야 합니다.', () => {});
+  test('여행하기 메뉴에 클릭 이벤트가 발생한 경우 router가 /travel 로 replace 되어야 합니다.', () => {
+    mockUsePathname.mockReturnValue('/travel');
 
-  test('홈 메뉴에 클릭 이벤트가 발생한 경우 router가 / 로 replace 되어야 합니다.', () => {});
+    const { getByText } = render(<NavigationBar />);
+    fireEvent.click(getByText('여행하기'));
 
-  test('기록하기 메뉴에 클릭 이벤트가 발생한 경우 router가 /record 로 replace 되어야 합니다.', () => {});
+    expect(mockRouter.replace).toHaveBeenCalledWith('/travel');
+  });
+
+  test('홈 메뉴에 클릭 이벤트가 발생한 경우 router가 / 로 replace 되어야 합니다.', () => {
+    mockUsePathname.mockReturnValue('/');
+
+    const { getByText } = render(<NavigationBar />);
+    fireEvent.click(getByText('홈'));
+
+    expect(mockRouter.replace).toHaveBeenCalledWith('/');
+  });
+
+  test('기록하기 메뉴에 클릭 이벤트가 발생한 경우 router가 /record 로 replace 되어야 합니다.', () => {
+    mockUsePathname.mockReturnValue('/record');
+
+    const { getByText } = render(<NavigationBar />);
+    fireEvent.click(getByText('기록하기'));
+
+    expect(mockRouter.replace).toHaveBeenCalledWith('/record');
+  });
 });


### PR DESCRIPTION
## Overview

- next/navigation 훅 mocking -> Next.js 라우터와의 의존성 제거
- /login, /my 경로에선 내비게이션 바가 렌더링 되지 않아야 하고, 다른 경로에선 내비게이션 바가 렌더링 되는지 확인
- 각 버튼을 눌렀을 때, 버튼 색이 변하는지 확인
- 각 버튼을 눌렀을 때, 올바른 경로로 이동하는지 확인 
